### PR TITLE
Add GNOME 50 as supported shell version in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,6 @@
   "description": "Enable mouse follows focus on Gnome Shell 45+ with multi monitors support",
   "version-name": "0.0.11",
   "url": "https://github.com/crisidev/mouse-follows-focus",
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "settings-schema": "org.gnome.shell.extensions.mouse-follows-focus"
 }


### PR DESCRIPTION
I've been using on GNOME 50—with extension version validation disabled—for a few weeks without issues.